### PR TITLE
chore: drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.11'
+  MAIN_PYTHON_VERSION: '3.12'
   PACKAGE_NAME: 'pyansys-tools-report'
   PACKAGE_NAMESPACE: 'ansys.tools.report'
   DOCUMENTATION_CNAME: 'report.tools.docs.pyansys.com'
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Build wheelhouse and perform smoke test
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Build wheelhouse and perform smoke test
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
           os: [ubuntu-latest, windows-latest]
-          python-version: ['3.9', '3.10', '3.11', '3.12']
+          python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: Run pytest
         uses: ansys/actions/tests-pytest@v7

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Refer to the [online documentation](https://report.tools.docs.pyansys.com/) to s
 This package may be installed following two procedures: either the pip package manager installation or
 the manual installation. The process to be followed for each of them is shown in the upcoming sections.
 
-The ``pyansys-tools-report`` package currently supports Python >=3.9 on Windows, Mac OS, and Linux.
+The ``pyansys-tools-report`` package currently supports Python >=3.10 on Windows, Mac OS, and Linux.
 
 ### Standard installation
 Install the latest release from [PyPi](https://pypi.org/project/pyansys-tools-report) with:
@@ -100,17 +100,17 @@ of installing PyAnsys Tools Report is downloading the wheelhouse archive from th
 corresponding machine architecture.
 
 Each wheelhouse archive contains all the python wheels necessary to install
-PyAnsys Tools Report from scratch on Windows and Linux for Python >=3.9. You can install
+PyAnsys Tools Report from scratch on Windows and Linux for Python >=3.10. You can install
 this on an isolated system with a fresh python or on a virtual environment.
 
-For example, on Linux with Python 3.9, unzip it and install it with the following:
+For example, on Linux with Python 3.10, unzip it and install it with the following:
 
 ```bash
-   unzip pyansys-tools-report-v0.8.dev0-wheelhouse-Linux-3.9.zip wheelhouse
+   unzip pyansys-tools-report-v0.8.dev0-wheelhouse-Linux-3.10.zip wheelhouse
    pip install pyansys-tools-report -f wheelhouse --no-index --upgrade --ignore-installed
 ```
 
-If you're on Windows with Python 3.9, unzip to a ``wheelhouse`` directory and
+If you're on Windows with Python 3.10, unzip to a ``wheelhouse`` directory and
 install using the same command as before.
 
 Consider installing using a [virtual environment](https://docs.python.org/3/library/venv.html).

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -11,7 +11,7 @@ Installation
 This package may be installed following two procedures: either the pip package manager installation or
 the manual installation. The process to be followed for each of them is shown in the upcoming sections.
 
-The ``pyansys-tools-report`` package currently supports Python >=3.9 on Windows, Mac OS, and Linux.
+The ``pyansys-tools-report`` package currently supports Python >=3.10 on Windows, Mac OS, and Linux.
 
 Install the latest release from `PyPi <https://pypi.org/project/pyansys-tools-report>`_ with:
 
@@ -44,18 +44,18 @@ of installing PyAnsys Tools Report is downloading the wheelhouse archive from th
 corresponding machine architecture.
 
 Each wheelhouse archive contains all the python wheels necessary to install
-PyAnsys Tools Report from scratch on Windows and Linux for Python >=3.9. You can install
+PyAnsys Tools Report from scratch on Windows and Linux for Python >=3.10. You can install
 this on an isolated system with a fresh python or on a virtual environment.
 
-For example, on Linux with Python 3.9, unzip it and install it with the following:
+For example, on Linux with Python 3.10, unzip it and install it with the following:
 
 .. code:: bash
 
-   unzip pyansys-tools-report-v0.8.dev0-wheelhouse-Linux-3.9.zip wheelhouse
+   unzip pyansys-tools-report-v0.8.dev0-wheelhouse-Linux-3.10.zip wheelhouse
    pip install pyansys-tools-report -f wheelhouse --no-index --upgrade --ignore-installed
 
 
-If you're on Windows with Python 3.9, unzip to a ``wheelhouse`` directory and
+If you're on Windows with Python 3.10, unzip to a ``wheelhouse`` directory and
 install using the same command as before.
 
 Consider installing using a `virtual environment <https://docs.python.org/3/library/venv.html>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "pyansys-tools-report"
 version = "0.8.dev0"
 dynamic = ["description"]
 readme = "README.md"
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
@@ -18,7 +18,6 @@ maintainers = [
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
As title says